### PR TITLE
Update VM type for ap region compatibility

### DIFF
--- a/cf-release/templates/infrastructure-single-vm-aws.yml
+++ b/cf-release/templates/infrastructure-single-vm-aws.yml
@@ -1056,7 +1056,7 @@ properties:
 compilation:
   network: default
   cloud_properties:
-    instance_type: c3.xlarge
+    instance_type: c4.xlarge
     availability_zone: (( meta.zones.z1 ))
 
 


### PR DESCRIPTION
c3.xlarge VMs are not available in Asia Pacific region, changed for c4 since it is ready in all regions.